### PR TITLE
Workaround for ruby-git untracked not taking into account .gitignore

### DIFF
--- a/lib/autoversion/gitter.rb
+++ b/lib/autoversion/gitter.rb
@@ -61,11 +61,9 @@ module Autoversion
     end
 
     def gitstatus_untracked_workaround
-      gem_rubygit_buggy_untracked_files = @repo.status.untracked.keys
       git_cmd = "git --work-tree=#{@repo.dir} --git-dir=#{@repo.dir}/.git " +
-                "ls-files -z -d -m -o -X .gitignore"
-      git_files = `#{git_cmd}`.split("\x0")
-      gem_rubygit_buggy_untracked_files & git_files
+                "ls-files -o -z --full-name --exclude-standard"
+      `#{git_cmd}`.split("\x0")
     end
 
   end

--- a/lib/autoversion/gitter.rb
+++ b/lib/autoversion/gitter.rb
@@ -22,18 +22,19 @@ module Autoversion
     end
 
     def dir_is_clean?
-      # sum = @repo.status.untracked.length + @repo.status.added.length + @repo.status.changed.length + @repo.status.deleted.length
-      # if sum > 0
-      #   puts "untracked: #{@repo.status.untracked}"
-      #   puts "added: #{@repo.status.added}"
-      #   puts "changed: #{@repo.status.changed}"
-      #   puts "deleted: #{@repo.status.deleted}"
-      # end
+      sum = gitstatus_untracked_workaround.length +
+            @repo.status.added.length +
+            @repo.status.changed.length +
+            @repo.status.deleted.length
 
-      # sum == 0
+      if sum > 0
+        puts "untracked: #{gitstatus_untracked_workaround.join(', ')}"
+        puts "added: #{@repo.status.added.keys.join(', ')}"
+        puts "changed: #{@repo.status.changed.keys.join(', ')}"
+        puts "deleted: #{@repo.status.deleted.keys.join(', ')}"
+      end
 
-      # Disabled for now. ruby-git doesn't seem to read the .gitignore files, so the untracked count is completely useless. 
-      true
+      sum == 0
     end
 
     def on_stable_branch?
@@ -59,5 +60,14 @@ module Autoversion
       @repo.add_tag "#{@config[:prefix]}#{version}"
     end
 
+    def gitstatus_untracked_workaround
+      gem_rubygit_buggy_untracked_files = @repo.status.untracked.keys
+      git_cmd = "git --work-tree=#{@repo.dir} --git-dir=#{@repo.dir}/.git " +
+                "ls-files -z -d -m -o -X .gitignore"
+      git_files = `#{git_cmd}`.split("\x0")
+      gem_rubygit_buggy_untracked_files & git_files
+    end
+
   end
 end
+


### PR DESCRIPTION
Second attempt. This time fully relying on git's ls-files command because I tested it and the rb-git would not include new .gitignore files as part of the untracked.